### PR TITLE
A correction to the code which checked that components of a concat si…

### DIFF
--- a/myhdl/_ShadowSignal.py
+++ b/myhdl/_ShadowSignal.py
@@ -199,7 +199,6 @@ class ConcatSignal(_ShadowSignal):
                 w = 1
             else:
                 w = len(a)
-
             lo = hi - w
 
             if isinstance(a, _Signal) and not a.driven:
@@ -239,6 +238,12 @@ class ConcatSignal(_ShadowSignal):
         hi = self._nrbits
         for a in self._args:
 
+            if isinstance(a, bool):
+                w = 1
+            else:
+                w = len(a)
+            lo = hi - w
+
             if isinstance(a, _Signal) and not a.driven:
                 # Check that signal a is driven and raise a warning if not
                 from myhdl.conversion._misc import _error
@@ -253,11 +258,6 @@ class ConcatSignal(_ShadowSignal):
                         "%s: %s[%s:%s]" % (_error.UndrivenSignal, self._name, hi, lo),
                         category=ToVerilogWarning)
 
-            if isinstance(a, bool):
-                w = 1
-            else:
-                w = len(a)
-            lo = hi - w
             if w == 1:
                 if isinstance(a, _Signal) and a.driven:
                     if a._type == bool:

--- a/myhdl/_ShadowSignal.py
+++ b/myhdl/_ShadowSignal.py
@@ -202,9 +202,16 @@ class ConcatSignal(_ShadowSignal):
             lo = hi - w
 
             if isinstance(a, _Signal) and a._name is None:
-                # We have seen a bug when a signal in the ConcatSignal is not
-                # driven. In this situation a._name is None. This gets written
-                # into the converted VHDL or Verilog and causes problems.
+                # We have seen a bug when a concat signal is created in the
+                # following way:
+                #
+                #     sig_list = [Signal(False) for n in range(32)]
+                #     concat_sig = ConcatSignal(*reversed(sig_list))
+                #
+                # It seems that the _name attribute on the signals in sig_list
+                # is only updated if an assignment is made to them. Otherwise
+                # _name is left as None. We need to check for None and raise
+                # a warning.
                 from myhdl.conversion._misc import _error
                 from myhdl import ToVHDLWarning
 
@@ -220,7 +227,12 @@ class ConcatSignal(_ShadowSignal):
             if w == 1:
                 if isinstance(a, _Signal) and a._name is not None:
                     # Check that a._name is not None as None should not be
-                    # written into the converted code
+                    # written into the converted code. If it is None then we
+                    # assume no assignment has been made to the signal
+                    # (otherwise the _name attribute would have been updated
+                    # by the _analyzeSigs function). In this situation the
+                    # signal should hold its init value (as handled in the
+                    # else branch).
                     if a._type == bool:  # isinstance(a._type , bool): <- doesn't work
                         lines.append("%s(%s) <= %s;" % (self._name, lo, a._name))
                     else:
@@ -251,9 +263,16 @@ class ConcatSignal(_ShadowSignal):
             lo = hi - w
 
             if isinstance(a, _Signal) and a._name is None:
-                # We have seen a bug when a signal in the ConcatSignal is not
-                # driven. In this situation a._name is None. This gets written
-                # into the converted VHDL or Verilog and causes problems.
+                # We have seen a bug when a concat signal is created in the
+                # following way:
+                #
+                #     sig_list = [Signal(False) for n in range(32)]
+                #     concat_sig = ConcatSignal(*reversed(sig_list))
+                #
+                # It seems that the _name attribute on the signals in sig_list
+                # is only updated if an assignment is made to them. Otherwise
+                # _name is left as None. We need to check for None and raise
+                # a warning.
                 from myhdl.conversion._misc import _error
                 from myhdl import ToVerilogWarning
 
@@ -269,7 +288,12 @@ class ConcatSignal(_ShadowSignal):
             if w == 1:
                 if isinstance(a, _Signal) and a._name is not None:
                     # Check that a._name is not None as None should not be
-                    # written into the converted code
+                    # written into the converted code. If it is None then we
+                    # assume no assignment has been made to the signal
+                    # (otherwise the _name attribute would have been updated
+                    # by the _analyzeSigs function). In this situation the
+                    # signal should hold its init value (as handled in the
+                    # else branch).
                     if a._type == bool:
                         lines.append("assign %s[%s] = %s;" % (self._name, lo, a._name))
                     else:

--- a/myhdl/_ShadowSignal.py
+++ b/myhdl/_ShadowSignal.py
@@ -201,8 +201,10 @@ class ConcatSignal(_ShadowSignal):
                 w = len(a)
             lo = hi - w
 
-            if isinstance(a, _Signal) and not a.driven:
-                # Check that signal a is driven and raise a warning if not
+            if isinstance(a, _Signal) and a._name is None:
+                # We have seen a bug when a signal in the ConcatSignal is not
+                # driven. In this situation a._name is None. This gets written
+                # into the converted VHDL or Verilog and causes problems.
                 from myhdl.conversion._misc import _error
                 from myhdl import ToVHDLWarning
 
@@ -216,7 +218,9 @@ class ConcatSignal(_ShadowSignal):
                         category=ToVHDLWarning)
 
             if w == 1:
-                if isinstance(a, _Signal) and a.driven:
+                if isinstance(a, _Signal) and a._name is not None:
+                    # Check that a._name is not None as None should not be
+                    # written into the converted code
                     if a._type == bool:  # isinstance(a._type , bool): <- doesn't work
                         lines.append("%s(%s) <= %s;" % (self._name, lo, a._name))
                     else:
@@ -224,7 +228,9 @@ class ConcatSignal(_ShadowSignal):
                 else:
                     lines.append("%s(%s) <= '%s';" % (self._name, lo, bin(ini[lo])))
             else:
-                if isinstance(a, _Signal) and a.driven:
+                if isinstance(a, _Signal) and a._name is not None:
+                    # Check that a._name is not None as None should not be
+                    # written into the converted code
                     lines.append("%s(%s-1 downto %s) <= %s;" % (self._name, hi, lo, a._name))
                 else:
                     lines.append('%s(%s-1 downto %s) <= "%s";' %
@@ -244,8 +250,10 @@ class ConcatSignal(_ShadowSignal):
                 w = len(a)
             lo = hi - w
 
-            if isinstance(a, _Signal) and not a.driven:
-                # Check that signal a is driven and raise a warning if not
+            if isinstance(a, _Signal) and a._name is None:
+                # We have seen a bug when a signal in the ConcatSignal is not
+                # driven. In this situation a._name is None. This gets written
+                # into the converted VHDL or Verilog and causes problems.
                 from myhdl.conversion._misc import _error
                 from myhdl import ToVerilogWarning
 
@@ -259,7 +267,9 @@ class ConcatSignal(_ShadowSignal):
                         category=ToVerilogWarning)
 
             if w == 1:
-                if isinstance(a, _Signal) and a.driven:
+                if isinstance(a, _Signal) and a._name is not None:
+                    # Check that a._name is not None as None should not be
+                    # written into the converted code
                     if a._type == bool:
                         lines.append("assign %s[%s] = %s;" % (self._name, lo, a._name))
                     else:
@@ -267,7 +277,9 @@ class ConcatSignal(_ShadowSignal):
                 else:
                     lines.append("assign %s[%s] = 'b%s;" % (self._name, lo, bin(ini[lo])))
             else:
-                if isinstance(a, _Signal) and a.driven:
+                if isinstance(a, _Signal) and a._name is not None:
+                    # Check that a._name is not None as None should not be
+                    # written into the converted code
                     lines.append("assign %s[%s-1:%s] = %s;" % (self._name, hi, lo, a._name))
                 else:
                     lines.append("assign %s[%s-1:%s] = 'b%s;" %


### PR DESCRIPTION
…gnal are driven.